### PR TITLE
Making this plugin work with sublime text 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RecenterTopBottom
 
-A [Sublime Text 2][ST2] plugin that cycles between moving the current line to the top, middle and bottom of the visible screen area.
+A [Sublime Text 3][ST3] plugin that cycles between moving the current line to the top, middle and bottom of the visible screen area.
 
 ## Installation
 
@@ -37,4 +37,4 @@ To change the ordering create a file called `Packages/User/RecenterTopBottom.sub
         "recenter_positions": ["middle", "top", "bottom"]
     }
 
-[ST2]: http://www.sublimetext.com/2
+[ST3]: http://www.sublimetext.com/3

--- a/recenter_top_bottom.py
+++ b/recenter_top_bottom.py
@@ -2,30 +2,24 @@ import sublime
 import sublime_plugin
 from itertools import cycle
 
-settings = sublime.load_settings('RecenterTopBottom.sublime-settings')
+_settings = None
+def settings():
+    return _settings or sublime.load_settings('RecenterTopBottom.sublime-settings')
 
-
-class Pref:
-    def load(self):
-        Pref.positions = settings.get('recenter_positions', ['top', 'middle', 'bottom'])
-Pref = Pref()
-Pref.load()
-settings.add_on_change('reload', lambda: Pref.load())
-
-
-POSNS = cycle(Pref.positions)
-
+positions = None
 
 class CaretWatcher(sublime_plugin.EventListener):
     def on_selection_modified(self, view):
         # caret has moved, reset positions to their default value
-        global POSNS
-        POSNS = cycle(Pref.positions)
+        global positions
+        positions = cycle(settings().get('recenter_positions'))
 
 
 class RecenterTopBottomCommand(sublime_plugin.TextCommand):
     def run(self, edit):
-        posn = next(POSNS)
+        global positions
+        positions = positions or cycle(settings().get('recenter_positions'))
+        posn = next(positions)
         if posn == 'top':
             self.show_at_top()
         elif posn == 'bottom':


### PR DESCRIPTION
This plugin was not working with Sublime Text 3.  I have never written a plugin for sublime text and I have very little knowledge of python so it is very likely that you can write this better than I did.

The basic problem is that in Sublime Text 3 you can not use the sublime api right away.  Because of this settings as not getting initialized properly and an error was occurring.  To fix this I don't attempt to read the settings until the modified event or run command.

With these changes the plugin now works with Sublime Text 3.  I did not test backward compatibility with Sublime Text 2, but I would imagine it still works.

Love this plugin!  Would love to see it working in Sublime Text 3!

Thanks,
Corsen 
